### PR TITLE
Overview container

### DIFF
--- a/TKAutoCompleteTextField/TKAutoCompleteTextField.h
+++ b/TKAutoCompleteTextField/TKAutoCompleteTextField.h
@@ -14,6 +14,7 @@
 
 // ui
 @property (nonatomic, strong, readonly) UITableView *suggestionView;
+@property (nonatomic, weak) UIView *overView;
 
 // options
 @property (nonatomic, assign) BOOL enableAutoComplete; // YES in default

--- a/TKAutoCompleteTextField/TKAutoCompleteTextField.m
+++ b/TKAutoCompleteTextField/TKAutoCompleteTextField.m
@@ -111,10 +111,15 @@ static NSString *kObserverKeyEnablePreInputSearch = @"enablePreInputSearch";
 - (void)stopObserving
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self removeObserver:self forKeyPath:kObserverKeyMatchSuggestions];
-    [self removeObserver:self forKeyPath:kObserverKeyBorderStyle];
-    [self removeObserver:self forKeyPath:kObserverKeyEnableAutoComplete];
-    [self removeObserver:self forKeyPath:kObserverKeyEnableStrictFirstMatch];
+    @try {
+        [self removeObserver:self forKeyPath:kObserverKeyMatchSuggestions];
+        [self removeObserver:self forKeyPath:kObserverKeyBorderStyle];
+        [self removeObserver:self forKeyPath:kObserverKeyEnableAutoComplete];
+        [self removeObserver:self forKeyPath:kObserverKeyEnableStrictFirstMatch];
+    }
+    @catch (NSException *exception) {
+        // wasn't observing anyway
+    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
@@ -314,9 +319,16 @@ static NSString *kObserverKeyEnablePreInputSearch = @"enablePreInputSearch";
 - (void)showSuggestionView
 {
     [self configureSuggestionViewForBorderStyle:self.borderStyle];
-    [self.superview bringSubviewToFront:self];
-    [self.superview insertSubview:self.suggestionView
-                     belowSubview:self];
+    if (_overView) {
+        CGPoint pt = [_overView convertPoint:self.frame.origin fromView:self.superview];
+        _suggestionView.frame = CGRectMake(pt.x, pt.y+self.frame.size.height,
+                                           _suggestionView.frame.size.width, _suggestionView.frame.size.height);
+        [_overView addSubview:_suggestionView];
+    } else {
+        [self.superview bringSubviewToFront:self];
+        [self.superview insertSubview:self.suggestionView
+                         belowSubview:self];
+    }
     self.suggestionView.userInteractionEnabled = YES;
 }
 


### PR DESCRIPTION
This adds an optional property for an external "overview" container to be specified.  When an auto complete field is in a tableviewcell, there is ambiguity on which view is receiving touch events.  By specifying an overView of the parent table, the suggestion popup table is able to position itself relative to the table cell but in the table view, therefore receiving the proper touch events.
