### PR TITLE
Added property to manage left and top margin for text and placeholder

### DIFF
--- a/TKAutoCompleteTextField/TKAutoCompleteTextField.h
+++ b/TKAutoCompleteTextField/TKAutoCompleteTextField.h
@@ -16,6 +16,10 @@
 @property (nonatomic, strong, readonly) UITableView *suggestionView;
 @property (nonatomic, weak) UIView *overView;
 
+@property (nonatomic, assign) NSInteger marginLefTextPlaceholder;
+@property (nonatomic, assign) NSInteger marginTopTextPlaceholder;
+
+
 // options
 @property (nonatomic, assign) BOOL enableAutoComplete; // YES in default
 @property (nonatomic, assign) BOOL enableStrictFirstMatch; // NO in default
@@ -26,5 +30,7 @@
 @property (nonatomic, weak) id<TKAutoCompleteTextFieldDelegate> autoCompleteDelegate;
 
 @property (nonatomic, strong) NSArray *suggestions;
+
+
 
 @end

--- a/TKAutoCompleteTextField/TKAutoCompleteTextField.m
+++ b/TKAutoCompleteTextField/TKAutoCompleteTextField.m
@@ -19,6 +19,9 @@ static NSString *kObserverKeyEnableAutoComplete = @"enableAutoComplete";
 static NSString *kObserverKeyEnableStrictFirstMatch = @"enableStrictFirstMatch";
 static NSString *kObserverKeyEnablePreInputSearch = @"enablePreInputSearch";
 
+static NSInteger kDefaultLeftMarginTextPlaceholder = 5;
+static NSInteger kDefaultTopMarginTextPlaceholder = 0;
+
 @interface TKAutoCompleteTextField () <UITableViewDataSource, UITableViewDelegate>
 
 @property (nonatomic, strong, readwrite) UITableView *suggestionView;
@@ -68,6 +71,8 @@ static NSString *kObserverKeyEnablePreInputSearch = @"enablePreInputSearch";
     self.enableAutoComplete = YES;
     self.enableStrictFirstMatch = NO;
     self.enablePreInputSearch = NO;
+    self.marginLefTextPlaceholder = kDefaultLeftMarginTextPlaceholder;
+    self.marginTopTextPlaceholder = kDefaultTopMarginTextPlaceholder;
     
     [self configureSuggestionView];
 }
@@ -399,6 +404,17 @@ static NSString *kObserverKeyEnablePreInputSearch = @"enablePreInputSearch";
     self.suggestionView.frame = frame;
     [self.suggestionView.layer setBorderWidth:0.5];
     [self.suggestionView.layer setBorderColor:[UIColor lightGrayColor].CGColor];
+}
+
+
+// placeholder position
+- (CGRect)textRectForBounds:(CGRect)bounds {
+    return CGRectInset(bounds, self.marginLefTextPlaceholder, self.marginTopTextPlaceholder);
+}
+
+// text position
+- (CGRect)editingRectForBounds:(CGRect)bounds {
+    return CGRectInset(bounds, self.marginLefTextPlaceholder, self.marginTopTextPlaceholder);
 }
 
 #pragma mark - UITableViewDataSource

--- a/TKAutoCompleteTextFieldSample/ViewController.m
+++ b/TKAutoCompleteTextFieldSample/ViewController.m
@@ -31,8 +31,9 @@ typedef NS_ENUM(NSInteger, TKAutoCompleteSampleType) {
     // sample 2
     self.textFieldSample2.suggestions = [self resourse];
     self.textFieldSample2.enableStrictFirstMatch = YES;
-    self.textFieldSample3.autoCompleteDelegate = self;
-    self.textFieldSample3.autoCompleteDataSource = self;
+    self.textFieldSample2.autoCompleteDelegate = self;
+    self.textFieldSample2.autoCompleteDataSource = self;
+    self.textFieldSample2.marginLefTextPlaceholder = 2;
     
     // sample 3
     self.textFieldSample3.suggestions = [self prefecture];


### PR DESCRIPTION
For default, the place holder put to close to the margin left of textfield, so I added the methods and properties to manage them.

Also, updated the example app to reflect the changes.