### PR TITLE
fixed layout of suggestion View

### DIFF
--- a/TKAutoCompleteTextField/TKAutoCompleteTextField.m
+++ b/TKAutoCompleteTextField/TKAutoCompleteTextField.m
@@ -268,6 +268,12 @@ static CGFloat kDefaultTopMarginTextPlaceholder = 0.f;
 
 #pragma mark - suggestionView
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect frame = self.suggestionView.frame;
+    self.suggestionView.frame = CGRectMake(frame.origin.x, frame.origin.y, self.bounds.size.width, frame.size.height);
+}
+
 - (void)configureSuggestionView
 {
     CGRect frame = self.frame;


### PR DESCRIPTION
I fixed issue that caused by different screen sizes. 
For ex default screen size in IB selected as iPhone 7 (4.7'') and when u run app on iPhone 5(4'') the right border of suggestions view goes out of base view. Please see screenshots
![the problem](https://user-images.githubusercontent.com/3427843/28156898-fb8b104a-67cd-11e7-97f1-24d265718678.png)
![fixed](https://user-images.githubusercontent.com/3427843/28156914-1172f92c-67ce-11e7-8e96-5657f23c0293.png)
